### PR TITLE
adds support for midigrid

### DIFF
--- a/shfts.lua
+++ b/shfts.lua
@@ -736,6 +736,7 @@ function quant_desc(quant,sel)
 end
 
 function init()
+  local grid = util.file_exists(_path.code.."midigrid") and include "midigrid/lib/mg_128" or grid
   g = grid.connect(1)
   g.key = function(x,y,z)
     if quant_held then


### PR DESCRIPTION
I believe this adds Midigrid support safely so that if the library is not present, shfts will fall back to the Monome grid library.
I verified that the script loads and LP Mini MK3 works when midigrid is present, and that the script loads correctly when the midigrid lib is not installed. However, I don't have a Monome Grid to test that it works as expected with this change.

Also maybe you simply don't want to support midigrid and that's ok too.